### PR TITLE
Remove missing page

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -10,4 +10,3 @@
     - faq
     - contributing
     - conduct
-    - history


### PR DESCRIPTION
I noticed the `history` page doesn't exist, but the site is still adding it to the navigation. After removing the name from `_data/docs.yml`, the issue goes away.

![screenshot 1525632636](https://user-images.githubusercontent.com/6250642/39676729-093ef3ea-5135-11e8-8c75-ee479542d3af.png)

Let me know if there's anything else you need regarding the PR. Thanks for providing such a great product.